### PR TITLE
GLM4使用仅仅需要API_KEY，不需要API_SECRET，在此删除，用于解决issue中的apiSecret can not be empty提问

### DIFF
--- a/src/main/java/com/zhipu/oapi/demo/V4OkHttpClientTest.java
+++ b/src/main/java/com/zhipu/oapi/demo/V4OkHttpClientTest.java
@@ -31,9 +31,7 @@ public class V4OkHttpClientTest {
 
     private static final String API_KEY = "";
 
-    private static final String API_SECRET = "";
-
-    private static final ClientV4 client = new ClientV4.Builder(API_KEY,API_SECRET).build();
+    private static final ClientV4 client = new ClientV4.Builder(API_KEY).build();
 
     private static final ObjectMapper mapper = defaultObjectMapper();
 


### PR DESCRIPTION
解决issue中的apiSecret can not be empty提问